### PR TITLE
Check for cocktails a user can make by including ingredients a user has a type of other than the parent

### DIFF
--- a/app/Services/CocktailService.php
+++ b/app/Services/CocktailService.php
@@ -259,7 +259,9 @@ class CocktailService
         $query = $this->db->table('cocktails AS c')
             ->select('c.id')
             ->join('cocktail_ingredients AS ci', 'ci.cocktail_id', '=', 'c.id')
-            ->join('ingredients AS i', 'i.id', '=', 'ci.ingredient_id')
+            ->join('ingredients AS i', function($join) {
+              $join->on('i.id','=','ci.ingredient_id')->orOn('i.parent_ingredient_id','=','ci.ingredient_id');
+            })
             ->leftJoin('cocktail_ingredient_substitutes AS cis', 'cis.cocktail_ingredient_id', '=', 'ci.id')
             ->where('optional', false)
             ->whereIn('i.id', function ($query) use ($userId) {
@@ -270,7 +272,7 @@ class CocktailService
             })
             ->groupBy('c.id')
             ->havingRaw('COUNT(*) >= (SELECT COUNT(*) FROM cocktail_ingredients WHERE cocktail_id = c.id AND optional = false)');
-        
+
         if ($limit) {
             $query->limit($limit);
         }

--- a/app/Services/CocktailService.php
+++ b/app/Services/CocktailService.php
@@ -260,23 +260,23 @@ class CocktailService
         $query = $this->db->table('cocktails AS c')
             ->select('c.id')
             ->join('cocktail_ingredients AS ci', 'ci.cocktail_id', '=', 'c.id');
-            if ($check_child_ingredients === true) {
-              $query->join('ingredients AS i', function($join) {
-                $join->on('i.id','=','ci.ingredient_id')->orOn('i.parent_ingredient_id','=','ci.ingredient_id');
-              });
-            } else {
-              $query->join('ingredients AS i', 'i.id', '=', 'ci.ingredient_id');
-            }
-            $query->leftJoin('cocktail_ingredient_substitutes AS cis', 'cis.cocktail_ingredient_id', '=', 'ci.id')
-            ->where('optional', false)
-            ->whereIn('i.id', function ($query) use ($userId) {
-                $query->select('ingredient_id')->from('user_ingredients')->where('user_id', $userId);
-            })
-            ->orWhereIn('cis.ingredient_id', function ($query) use ($userId) {
-                $query->select('ingredient_id')->from('user_ingredients')->where('user_id', $userId);
-            })
-            ->groupBy('c.id')
-            ->havingRaw('COUNT(*) >= (SELECT COUNT(*) FROM cocktail_ingredients WHERE cocktail_id = c.id AND optional = false)');
+        if ($check_child_ingredients === true) {
+            $query->join('ingredients AS i', function ($join) {
+                $join->on('i.id', '=', 'ci.ingredient_id')->orOn('i.parent_ingredient_id', '=', 'ci.ingredient_id');
+            });
+        } else {
+            $query->join('ingredients AS i', 'i.id', '=', 'ci.ingredient_id');
+        }
+        $query->leftJoin('cocktail_ingredient_substitutes AS cis', 'cis.cocktail_ingredient_id', '=', 'ci.id')
+        ->where('optional', false)
+        ->whereIn('i.id', function ($query) use ($userId) {
+            $query->select('ingredient_id')->from('user_ingredients')->where('user_id', $userId);
+        })
+        ->orWhereIn('cis.ingredient_id', function ($query) use ($userId) {
+            $query->select('ingredient_id')->from('user_ingredients')->where('user_id', $userId);
+        })
+        ->groupBy('c.id')
+        ->havingRaw('COUNT(*) >= (SELECT COUNT(*) FROM cocktail_ingredients WHERE cocktail_id = c.id AND optional = false)');
 
         if ($limit) {
             $query->limit($limit);

--- a/app/Services/CocktailService.php
+++ b/app/Services/CocktailService.php
@@ -256,13 +256,18 @@ class CocktailService
      */
     public function getCocktailsByUserIngredients(int $userId, ?int $limit = null): Collection
     {
+        $check_child_ingredients = env('CHECK_CHILD_INGREDIENTS', 'false');
         $query = $this->db->table('cocktails AS c')
             ->select('c.id')
-            ->join('cocktail_ingredients AS ci', 'ci.cocktail_id', '=', 'c.id')
-            ->join('ingredients AS i', function($join) {
-              $join->on('i.id','=','ci.ingredient_id')->orOn('i.parent_ingredient_id','=','ci.ingredient_id');
-            })
-            ->leftJoin('cocktail_ingredient_substitutes AS cis', 'cis.cocktail_ingredient_id', '=', 'ci.id')
+            ->join('cocktail_ingredients AS ci', 'ci.cocktail_id', '=', 'c.id');
+            if ($check_child_ingredients === true) {
+              $query->join('ingredients AS i', function($join) {
+                $join->on('i.id','=','ci.ingredient_id')->orOn('i.parent_ingredient_id','=','ci.ingredient_id');
+              });
+            } else {
+              $query->join('ingredients AS i', 'i.id', '=', 'ci.ingredient_id');
+            }
+            $query->leftJoin('cocktail_ingredient_substitutes AS cis', 'cis.cocktail_ingredient_id', '=', 'ci.id')
             ->where('optional', false)
             ->whereIn('i.id', function ($query) use ($userId) {
                 $query->select('ingredient_id')->from('user_ingredients')->where('user_id', $userId);


### PR DESCRIPTION
This resolves #95, and includes in the calculation of cocktails a user can make ingredients that have the same parent ingredient as the cocktail requires. I can't think of a situation in which this would be undesirable, since listing an ingredient as a parent implies compatibility in a cocktail.

My test:
Add all ingredients to an Airmail cocktail onto a user's shelf except the white rum
Add a new ingredient with the parent of white rum
The Airmail should show up as a cocktail the user can make

