### PR TITLE
Improved query filters

### DIFF
--- a/app/Models/Cocktail.php
+++ b/app/Models/Cocktail.php
@@ -12,6 +12,7 @@ use Symfony\Component\Uid\Ulid;
 use Kami\Cocktail\SearchActions;
 use Spatie\Sluggable\SlugOptions;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -210,6 +211,13 @@ class Cocktail extends Model implements SiteSearchable
         }
 
         return (int) round($this->ratings()->avg('rating') ?? 0);
+    }
+
+    public function scopeUserFavorites(Builder $baseQuery, int $userId): Builder
+    {
+        return $baseQuery->whereIn('id', function ($query) use ($userId) {
+            $query->select('cocktail_id')->from('cocktail_favorites')->where('user_id', $userId);
+        });
     }
 
     public function toSiteSearchArray(): array

--- a/app/Services/ExportService.php
+++ b/app/Services/ExportService.php
@@ -51,7 +51,16 @@ class ExportService
 
         $zip->addGlob(storage_path('bar-assistant/uploads/*/*'), options: ['remove_path' => storage_path('bar-assistant')]);
         foreach ($tablesToExport as $tableName) {
-            if ($content = json_encode(DB::table($tableName)->get()->toArray())) {
+            $tableData = DB::table($tableName)->get()->map(function ($row) {
+                // Reset user_id since we can't have the same ids in new instance
+                if(property_exists($row, 'user_id')) {
+                    $row->user_id = 1;
+                }
+
+                return $row;
+            });
+
+            if ($content = json_encode($tableData->toArray())) {
                 $zip->addFromString($tableName . '.json', $content);
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "laravel/scout": "^9.4",
         "laravel/tinker": "^2.7",
         "meilisearch/meilisearch-php": "^1.0",
+        "spatie/laravel-query-builder": "^5.2",
         "spatie/laravel-responsecache": "^7.4",
         "spatie/laravel-sluggable": "^3.4",
         "srwiez/thumbhash": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74510cd8a8dda6f53b7332f84c074615",
+    "content-hash": "e84b18a72cad187a884c0754fd8ffa64",
     "packages": [
         {
             "name": "brick/math",
@@ -4184,6 +4184,78 @@
                 }
             ],
             "time": "2023-04-27T08:09:01+00:00"
+        },
+        {
+            "name": "spatie/laravel-query-builder",
+            "version": "5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-query-builder.git",
+                "reference": "7b3911f61dcaa27804b80f30b73a468a9539e850"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-query-builder/zipball/7b3911f61dcaa27804b80f30b73a468a9539e850",
+                "reference": "7b3911f61dcaa27804b80f30b73a468a9539e850",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^9.0|^10.0",
+                "illuminate/http": "^9.0|^10.0",
+                "illuminate/support": "^9.0|^10.0",
+                "php": "^8.0",
+                "spatie/laravel-package-tools": "^1.11"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "mockery/mockery": "^1.4",
+                "orchestra/testbench": "^7.0|^8.0",
+                "pestphp/pest": "^1.20",
+                "spatie/laravel-ray": "^1.28"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\QueryBuilder\\QueryBuilderServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\QueryBuilder\\": "src",
+                    "Spatie\\QueryBuilder\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily build Eloquent queries from API requests",
+            "homepage": "https://github.com/spatie/laravel-query-builder",
+            "keywords": [
+                "laravel-query-builder",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-query-builder/issues",
+                "source": "https://github.com/spatie/laravel-query-builder"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-02-24T15:48:30+00:00"
         },
         {
             "name": "spatie/laravel-responsecache",

--- a/docs/open-api-spec.yml
+++ b/docs/open-api-spec.yml
@@ -113,19 +113,44 @@ paths:
     get:
       parameters:
       - in: query
-        name: user_id
+        name: filter
         required: false
+        description: Filter by specific parameters
+        explode: true
+        style: deepObject
         schema:
-          type: integer
-          example: 1
-        description: 'Show only cocktails made by a specifc user'
+          type: object
+          properties:
+            name:
+             type: string
+             example: "old"
+            ingredient_name:
+             type: string
+             example: "campari"
+            ingredient_id:
+             type: integer
+             example: 3
+            tag_id:
+             type: integer
+             example: 4
+            user_id:
+             type: integer
+             example: 3
+            glass_id:
+             type: integer
+             example: 1
+            cocktail_method_id:
+             type: integer
+             example: 1
+            favorites:
+             type: boolean
       - in: query
-        name: order_by
+        name: sort
         required: false
         schema:
           type: string
-          example: created_at:desc
-        description: 'Sort cocktails'
+          example: name,-created_at
+        description: Sort by specific parameters
       tags:
         - "Cocktails"
       summary: 'Show a paginated list of cocktails'


### PR DESCRIPTION
This PR improves path query implementation:

For example:
/cocktails?filter[name]=old&filter[tag_id]=3,5,6&sort=-created_at

This will currently be a breaking change for /cocktails and /ingredients endpoints