### PR TITLE
Bulk Cocktail Upload via json

### DIFF
--- a/app/OpenAPI/Schemas/BulkImportCounts.php
+++ b/app/OpenAPI/Schemas/BulkImportCounts.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kami\Cocktail\OpenAPI\Schemas;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(required: ['total','created','skipped','overwritten','failed'])]
+class BulkImportCounts
+{
+    #[OAT\Property(type: 'integer', example: 10)]
+    public int $total;
+
+    #[OAT\Property(type: 'integer', example: 6)]
+    public int $created;
+
+    #[OAT\Property(type: 'integer', example: 2)]
+    public int $skipped;
+
+    #[OAT\Property(type: 'integer', example: 1)]
+    public int $overwritten;
+
+    #[OAT\Property(type: 'integer', example: 1)]
+    public int $failed;
+}
+
+

--- a/app/OpenAPI/Schemas/BulkImportItem.php
+++ b/app/OpenAPI/Schemas/BulkImportItem.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kami\Cocktail\OpenAPI\Schemas;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(required: ['status'])]
+class BulkImportItem
+{
+    #[OAT\Property(description: 'Import outcome status', type: 'string', example: 'created', enum: ['created', 'skipped', 'overwritten', 'failed'])]
+    public string $status;
+
+    #[OAT\Property(description: 'Basic cocktail data when applicable', type: CocktailBasicResource::class, nullable: true)]
+    public ?CocktailBasicResource $cocktail = null;
+
+    #[OAT\Property(description: 'Source recipe name when known', type: 'string', nullable: true, example: 'Negroni')]
+    public ?string $name = null;
+
+    #[OAT\Property(description: 'Error message when failed', type: 'string', nullable: true, example: 'Validation failed: missing ingredients array')]
+    public ?string $error = null;
+
+    #[OAT\Property(description: 'Original index in the submitted array', type: 'integer', nullable: true, example: 0)]
+    public ?int $index = null;
+}
+
+

--- a/app/OpenAPI/Schemas/BulkImportResponse.php
+++ b/app/OpenAPI/Schemas/BulkImportResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kami\Cocktail\OpenAPI\Schemas;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(required: ['data'])]
+class BulkImportResponse
+{
+    #[OAT\Property(property: 'data', type: 'object', properties: [
+        new OAT\Property(property: 'items', type: 'array', items: new OAT\Items(ref: self::class . '\\ItemRef')),
+        new OAT\Property(property: 'counts', type: BulkImportCounts::class),
+    ], required: ['items','counts'])]
+    public array $data;
+
+    #[OAT\Schema(schema: 'ItemRef', ref: BulkImportItem::class)]
+    public mixed $_itemsRef;
+}
+
+

--- a/app/OpenAPI/WrapArrayWithData.php
+++ b/app/OpenAPI/WrapArrayWithData.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kami\Cocktail\OpenAPI;
+
+use OpenApi\Attributes as OAT;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class WrapArrayWithData extends OAT\JsonContent
+{
+    /**
+     * @param class-string $className
+     */
+    public function __construct(string $className)
+    {
+        parent::__construct(properties: [new OAT\Property(property: 'data', type: 'array', items: new OAT\Items(ref: $className))], required: ['data']);
+    }
+}
+
+


### PR DESCRIPTION
This is a feature add that is supported by a [corresponding PR](https://github.com/karlomikus/vue-salt-rim/pull/366) in vue-salt-rim

The goal is to improve cocktail import function to support bulk uploads. To accomplish this, I've updated API documentation to reflect changes in request structure and response format, added tests for various import scenarios including creation, and also added the ability to skip, overwrite, and handle partial failures.