### PR TITLE
Optionally hide "My Shelf" and associated features.

### DIFF
--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -42,6 +42,7 @@ class ServerController extends Controller
                 'search_version' => $searchVersion,
                 'is_password_login_enabled' => config('bar-assistant.enable_password_login') === true,
                 'is_ai_enabled' => config('bar-assistant.ai.provider') !== null,
+                'is_user_shelf_enabled' => config('bar-assistant.enable_user_shelf') === true,
             ]
         ]);
     }

--- a/app/OpenAPI/Schemas/ServerVersion.php
+++ b/app/OpenAPI/Schemas/ServerVersion.php
@@ -6,7 +6,7 @@ namespace Kami\Cocktail\OpenAPI\Schemas;
 
 use OpenApi\Attributes as OAT;
 
-#[OAT\Schema(required: ['version', 'type', 'search_host', 'search_version', 'latest_version', 'is_latest', 'is_password_login_enabled', 'is_ai_enabled'])]
+#[OAT\Schema(required: ['version', 'type', 'search_host', 'search_version', 'latest_version', 'is_latest', 'is_password_login_enabled', 'is_ai_enabled', 'is_user_shelf_enabled'])]
 class ServerVersion
 {
     #[OAT\Property(example: '1.0.0', description: 'Version of the server')]
@@ -25,4 +25,6 @@ class ServerVersion
     public bool $isPasswordLoginEnabled;
     #[OAT\Property(property: 'is_ai_enabled', example: true, description: 'Whether AI features are enabled')]
     public bool $isAiEnabled;
+    #[OAT\Property(property: 'is_user_shelf_enabled', example: true, description: 'Whether the per-user shelf feature is enabled')]
+    public bool $isUserShelfEnabled;
 }

--- a/config/bar-assistant.php
+++ b/config/bar-assistant.php
@@ -75,6 +75,8 @@ return [
 
     'enable_password_login' => (bool) env('ENABLE_PASSWORD_LOGIN', true),
 
+    'enable_user_shelf' => (bool) env('ENABLE_USER_SHELF', true),
+
     'scraping_client' => [
         'proxy' => env('SCRAPING_HTTP_PROXY', null),
         'cert' => env('SCRAPING_CLIENT_CERT', null),

--- a/tests/Feature/Http/ServerControllerTest.php
+++ b/tests/Feature/Http/ServerControllerTest.php
@@ -16,6 +16,7 @@ class ServerControllerTest extends TestCase
         $this->assertNotNull($response['data']['version']);
         $this->assertNotNull($response['data']['search_host']);
         $this->assertNotNull($response['data']['search_version']);
+        $this->assertNotNull($response['data']['is_user_shelf_enabled']);
     }
 
     public function test_openapi_response(): void


### PR DESCRIPTION
# What

This change adds an environment variable and an API flag that allows an administrator to disable user-specific ingredient shelves ("My Shelf") and associated features.

There's a corresponding PR to Salt-Rim which honors this flag by hiding these features on the front-end: https://github.com/karlomikus/vue-salt-rim/pull/402

It has no direct effect on the app other than making this preference visible to frontends such as Salt-Rim, and API requests concerning per-user shelves will continue to function as normal.

# Why

I've found per-user ingredient shelves to have no utility for myself or my housemates, and we all find that having multiple shelves is confusing, frequently resulting in cocktail searches and recipe recommendations not functioning correctly due to ingredients being distrubted between different lists.

The functionality already present in "Bar Shelf" serves our needs better, and I've seen that some other users have expressed similar confusion:

* https://github.com/karlomikus/bar-assistant/discussions/430
* https://github.com/karlomikus/bar-assistant/issues/519

# Usage

For default behavior, in which each user has their own "My Shelf" in addition to a shared global "Bar Shelf", make no changes.

To hide "My Shelf" and associated features like "Cocktails I Can Make" (leaving "Bar Shelf" and "Bar Shelf Cocktails" unaffected), add the following environment variable to `docker-compose.yaml`

```
    environment:
      - ENABLE_USER_SHELF=false  # Default true
```

# Schema

The status of this setting is presented by the `api/server/version` endpoint as the `data: is_user_shelf_enabled` boolean.