### PR TITLE
Add state parameter for Pocket ID

### DIFF
--- a/app/Http/Controllers/SSOAuthController.php
+++ b/app/Http/Controllers/SSOAuthController.php
@@ -34,8 +34,8 @@ class SSOAuthController extends Controller
         /** @var \Laravel\Socialite\Two\AbstractProvider */
         $driver = Socialite::driver($validProvider->value);
 
-        // Authelia always requires a state parameter to be set
-        if ($validProvider === OauthProvider::Authelia) {
+        // Authelia and Pocket ID (>= 2.10) require a state parameter
+        if ($validProvider === OauthProvider::Authelia || $validProvider === OauthProvider::PocketId) {
             $driver->with(['state' => Str::random(40)]);
         }
 


### PR DESCRIPTION
Fixes #601

Pocket ID auth starting with version 2.10 requires a state parameter.  This adds the same, similar to Authelia.